### PR TITLE
Resolve deprecation: A tree builder without a root node is deprecated…

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -17,8 +17,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('bilendi_dev_express');
+        $treeBuilder = new TreeBuilder('bilendi_dev_express');
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for


### PR DESCRIPTION
… since Symfony 4.2 and will not be supported anymore in 5.0.